### PR TITLE
fix: Ensure private declarations are not leaked

### DIFF
--- a/lib/src/constructor_declaration.dart
+++ b/lib/src/constructor_declaration.dart
@@ -8,7 +8,9 @@ import 'package:dartdoc_json/src/utils.dart';
 Map<String, dynamic>? serializeConstructorDeclaration(
   ConstructorDeclaration constructor,
 ) {
-  if (constructor.name?.lexeme.startsWith('_') ?? false) {
+  final annotations = serializeAnnotations(constructor.metadata);
+  if ((constructor.name?.lexeme.startsWith('_') ?? false) ||
+      hasPrivateAnnotation(annotations)) {
     return null;
   }
   final className = (constructor.parent! as ClassDeclaration).name.lexeme;
@@ -23,6 +25,6 @@ Map<String, dynamic>? serializeConstructorDeclaration(
     'factory': constructor.factoryKeyword == null ? null : true,
     'description': serializeComment(constructor.documentationComment),
     'parameters': serializeFormalParameterList(constructor.parameters),
-    'annotations': serializeAnnotations(constructor.metadata),
+    'annotations': annotations,
   });
 }

--- a/lib/src/extension_declaration.dart
+++ b/lib/src/extension_declaration.dart
@@ -5,16 +5,21 @@ import 'package:dartdoc_json/src/member_list.dart';
 import 'package:dartdoc_json/src/type_parameter_list.dart';
 import 'package:dartdoc_json/src/utils.dart';
 
-/// Serializes a MixinDeclaration into a json-compatible object.
-Map<String, dynamic> serializeExtensionDeclaration(
+/// Serializes an ExtensionDeclaration into a json-compatible object.
+Map<String, dynamic>? serializeExtensionDeclaration(
   ExtensionDeclaration extension,
 ) {
+  final annotations = serializeAnnotations(extension.metadata);
+  if ((extension.name?.lexeme.startsWith('_') ?? false) ||
+      hasPrivateAnnotation(annotations)) {
+    return null;
+  }
   return filterMap(<String, dynamic>{
     'kind': 'extension',
     'name': extension.name?.lexeme,
     'typeParameters': serializeTypeParameterList(extension.typeParameters),
     'on': extension.extendedType.toString(),
-    'annotations': serializeAnnotations(extension.metadata),
+    'annotations': annotations,
     'description': serializeComment(extension.documentationComment),
     'members': serializeMemberList(extension.members),
   });

--- a/lib/src/mixin_declaration.dart
+++ b/lib/src/mixin_declaration.dart
@@ -8,14 +8,18 @@ import 'package:dartdoc_json/src/type_parameter_list.dart';
 import 'package:dartdoc_json/src/utils.dart';
 
 /// Serializes a MixinDeclaration into a json-compatible object.
-Map<String, dynamic> serializeMixinDeclaration(MixinDeclaration mixin) {
+Map<String, dynamic>? serializeMixinDeclaration(MixinDeclaration mixin) {
+  final annotations = serializeAnnotations(mixin.metadata);
+  if (mixin.name.lexeme.startsWith('_') || hasPrivateAnnotation(annotations)) {
+    return null;
+  }
   return filterMap(<String, dynamic>{
     'kind': 'mixin',
     'name': mixin.name.lexeme,
     'typeParameters': serializeTypeParameterList(mixin.typeParameters),
     'implements': serializeImplementsClause(mixin.implementsClause),
     'on': serializeOnClause(mixin.onClause),
-    'annotations': serializeAnnotations(mixin.metadata),
+    'annotations': annotations,
     'description': serializeComment(mixin.documentationComment),
     'members': serializeMemberList(mixin.members),
   });

--- a/test/constructor_declaration_test.dart
+++ b/test/constructor_declaration_test.dart
@@ -17,6 +17,18 @@ void main() {
       );
     });
 
+    test('private constructors', () {
+      expect(
+        parseConstructors('''
+          class X {
+            X._private();
+            @internal X();
+          }
+        '''),
+        isEmpty,
+      );
+    });
+
     test('named constructors', () {
       expect(
         parseConstructors('''


### PR DESCRIPTION
Ensure that private constructors/extensions/mixins are not reported in the output. This check already exists for all other declaration types.