### PR TITLE
ci: Use the dart-lang/setup-dart action

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cedx/setup-dart@v3
+      - uses: dart-lang/setup-dart@v1
       - run: dart pub get
       - run: dart format . --set-exit-if-changed
       - run: dart analyze --fatal-warnings --fatal-infos
@@ -21,6 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cedx/setup-dart@v3
+      - uses: dart-lang/setup-dart@v1
       - run: dart pub get
       - run: dart test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path: ^1.8.3
 
 dev_dependencies:
-  flame_lint: ^0.1.3
+  flame_lint: ^0.2.0
   test: any
 
 executables:


### PR DESCRIPTION
Since `cedx/setup-dart` repository was deleted (or made private), we need to switch to another action.