### PR TITLE
chore: Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Upgrade `flame_lint` version
+- Detect the "required" keyword in the parameter list
 
 ## 0.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartdoc_json
 description: Package for rendering dartdocs as JSON files.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/bluefireteam/dartdoc_json
 funding:
   - https://patreon.com/bluefireoss


### PR DESCRIPTION
We should pull in melos here eventually so that we don't have to manually handle the changelogs.