### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -14,7 +14,7 @@ List<Map<String, dynamic>>? serializeAnnotations(
     if (annotation.arguments != null) {
       record['arguments'] = [
         for (final argument in annotation.arguments!.arguments)
-          argument.toString()
+          argument.toString(),
       ];
     }
     out.add(record);

--- a/lib/src/combinators.dart
+++ b/lib/src/combinators.dart
@@ -6,7 +6,7 @@ List<String> serializeCombinators<C extends Combinator>(
   return [
     for (final combinator in combinators)
       if (combinator is C)
-        for (var name in _names(combinator)) name.token.lexeme
+        for (final name in _names(combinator)) name.token.lexeme,
   ];
 }
 

--- a/lib/src/enum_constant_arguments.dart
+++ b/lib/src/enum_constant_arguments.dart
@@ -8,6 +8,6 @@ List<String>? serializeEnumConstantArguments(
     return null;
   }
   return <String>[
-    for (final argument in arguments.argumentList.arguments) argument.toString()
+    for (final argument in arguments.argumentList.arguments) argument.toString(),
   ];
 }

--- a/lib/src/enum_constant_arguments.dart
+++ b/lib/src/enum_constant_arguments.dart
@@ -8,6 +8,7 @@ List<String>? serializeEnumConstantArguments(
     return null;
   }
   return <String>[
-    for (final argument in arguments.argumentList.arguments) argument.toString(),
+    for (final argument in arguments.argumentList.arguments)
+      argument.toString(),
   ];
 }

--- a/lib/src/enum_declaration.dart
+++ b/lib/src/enum_declaration.dart
@@ -25,7 +25,7 @@ Map<String, dynamic>? serializeEnumDeclaration(EnumDeclaration enum_) {
     'description': serializeComment(enum_.documentationComment),
     'values': [
       for (final value in enum_.constants)
-        serializeEnumConstantDeclaration(value)
+        serializeEnumConstantDeclaration(value),
     ]..removeWhere((dynamic item) => item == null),
     'members': serializeMemberList(enum_.members),
   });

--- a/lib/src/formal_parameter.dart
+++ b/lib/src/formal_parameter.dart
@@ -2,8 +2,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dartdoc_json/src/utils.dart';
 
 /// Converts a FormalParameter into a json-compatible object.
-Map<String, dynamic> serializeFormalParameter(FormalParameter _parameter) {
-  var p = _parameter;
+Map<String, dynamic> serializeFormalParameter(FormalParameter parameter) {
+  var p = parameter;
   String? defaultValue;
   if (p is DefaultFormalParameter) {
     defaultValue = p.defaultValue?.toString();

--- a/lib/src/formal_parameter_list.dart
+++ b/lib/src/formal_parameter_list.dart
@@ -13,7 +13,7 @@ Map<String, dynamic>? serializeFormalParameterList(
   final nNamedParameters = list.parameters.where((p) => p.isNamed).length;
   final out = <String, dynamic>{};
   out['all'] = [
-    for (final param in list.parameters) serializeFormalParameter(param)
+    for (final param in list.parameters) serializeFormalParameter(param),
   ];
   if (nPositionalParameters != 0) {
     out['positional'] = nPositionalParameters;

--- a/lib/src/member_list.dart
+++ b/lib/src/member_list.dart
@@ -7,12 +7,12 @@ import 'package:dartdoc_json/src/method_declaration.dart';
 ///
 /// An error will be thrown if this function encounters a member of unknown
 /// type.
-List<dynamic>? serializeMemberList(ast.NodeList<ast.ClassMember> _members) {
-  if (_members.isEmpty) {
+List<dynamic>? serializeMemberList(ast.NodeList<ast.ClassMember> members) {
+  if (members.isEmpty) {
     return null;
   }
   final out = <dynamic>[];
-  for (final member in _members) {
+  for (final member in members) {
     Map<String, dynamic>? json;
     if (member is ast.ConstructorDeclaration) {
       json = serializeConstructorDeclaration(member);

--- a/lib/src/type_parameter.dart
+++ b/lib/src/type_parameter.dart
@@ -1,12 +1,12 @@
 import 'package:analyzer/dart/ast/ast.dart' as ast;
 
 /// Converts a TypeParameter into a json-compatible object.
-Map<String, String> serializeTypeParameter(ast.TypeParameter _type) {
+Map<String, String> serializeTypeParameter(ast.TypeParameter type) {
   final out = {
-    'name': _type.name.lexeme,
+    'name': type.name.lexeme,
   };
-  if (_type.bound != null) {
-    out['extends'] = _type.bound!.toString();
+  if (type.bound != null) {
+    out['extends'] = type.bound!.toString();
   }
   return out;
 }

--- a/lib/src/type_parameter_list.dart
+++ b/lib/src/type_parameter_list.dart
@@ -7,6 +7,6 @@ List<dynamic>? serializeTypeParameterList(ast.TypeParameterList? types) {
     return null;
   }
   return <dynamic>[
-    for (final type in types.typeParameters) serializeTypeParameter(type)
+    for (final type in types.typeParameters) serializeTypeParameter(type),
   ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ^6.3.0
+  analyzer: ^6.2.0
   args: ^2.3.1
   meta: ^1.7.0
   path: ^1.8.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.4.0
+  analyzer: ^6.3.0
   args: ^2.3.1
   meta: ^1.7.0
   path: ^1.8.3
 
 dev_dependencies:
-  flame_lint: ^0.2.0
+  flame_lint: ^1.1.1
   test: any
 
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ funding:
   - https://www.buymeacoffee.com/bluefire
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   analyzer: ^6.2.0

--- a/test/class_declaration_test.dart
+++ b/test/class_declaration_test.dart
@@ -39,8 +39,8 @@ void main() {
           'kind': 'class',
           'name': 'X',
           'typeParameters': [
-            {'name': 'T', 'extends': 'Base'}
-          ]
+            {'name': 'T', 'extends': 'Base'},
+          ],
         },
       );
     });
@@ -55,7 +55,7 @@ void main() {
             {'name': 'T', 'extends': 'A<B>'},
             {'name': 'S', 'extends': 'Base2'},
             {'name': 'R'},
-          ]
+          ],
         },
       );
     });

--- a/test/constructor_declaration_test.dart
+++ b/test/constructor_declaration_test.dart
@@ -109,7 +109,7 @@ void main() {
             'annotations': [
               {
                 'name': '@Deprecated',
-                'arguments': ["'really'"]
+                'arguments': ["'really'"],
               },
               {'name': '@external'},
             ],
@@ -132,8 +132,8 @@ void main() {
             'parameters': {
               'all': [
                 {'name': 'x', 'type': 'int'},
-                {'name': 'y', 'type': 'double?'}
-              ]
+                {'name': 'y', 'type': 'double?'},
+              ],
             },
           },
         ],
@@ -204,7 +204,7 @@ void main() {
             'parameters': {
               'all': [
                 {'name': 'this.x'},
-              ]
+              ],
             },
           },
         ],

--- a/test/enum_declaration_test.dart
+++ b/test/enum_declaration_test.dart
@@ -63,11 +63,11 @@ void main() {
           'values': [
             {
               'name': 'a',
-              'arguments': ["'one'"]
+              'arguments': ["'one'"],
             },
             {
               'name': 'b',
-              'arguments': ["'two'", '2']
+              'arguments': ["'two'", '2'],
             },
           ],
         },

--- a/test/field_declaration_test.dart
+++ b/test/field_declaration_test.dart
@@ -61,7 +61,7 @@ void main() {
             'kind': 'field',
             'name': 'a',
             'extraNames': ['b', 'c'],
-            'type': 'int'
+            'type': 'int',
           }
         ],
       );

--- a/test/function_declaration_test.dart
+++ b/test/function_declaration_test.dart
@@ -17,7 +17,7 @@ void main() {
             'all': [
               {'name': 'a', 'type': 'int'},
               {'name': 'b', 'type': 'int'},
-            ]
+            ],
           },
         },
       );
@@ -47,7 +47,7 @@ void main() {
           'name': 'moo',
           'returns': 'void',
           'typeParameters': [
-            {'name': 'T'}
+            {'name': 'T'},
           ],
           'parameters': {
             'all': [

--- a/test/generic_type_alias_test.dart
+++ b/test/generic_type_alias_test.dart
@@ -61,7 +61,7 @@ void main() {
           'kind': 'typedef',
           'name': 'A',
           'typeParameters': [
-            {'name': 'T', 'extends': 'Game'}
+            {'name': 'T', 'extends': 'Game'},
           ],
         },
       );

--- a/test/method_declaration_test.dart
+++ b/test/method_declaration_test.dart
@@ -47,8 +47,8 @@ void main() {
             'name': 'flame',
             'returns': 'int',
             'typeParameters': [
-              {'name': 'T'}
-            ]
+              {'name': 'T'},
+            ],
           },
         ],
       );
@@ -70,8 +70,8 @@ void main() {
               'all': [
                 {'name': 'a', 'type': 'bool'},
                 {'name': 'b', 'type': 'int'},
-              ]
-            }
+              ],
+            },
           },
         ],
       );
@@ -138,7 +138,7 @@ void main() {
             'name': 'xyz',
             'parameters': {
               'all': [
-                {'name': 'value', 'type': 'int'}
+                {'name': 'value', 'type': 'int'},
               ],
             },
           },
@@ -177,8 +177,8 @@ void main() {
             'name': 'operator==',
             'parameters': {
               'all': [
-                {'name': 'other', 'type': 'Object'}
-              ]
+                {'name': 'other', 'type': 'Object'},
+              ],
             },
             'returns': 'bool',
           },

--- a/test/mixin_declaration_test.dart
+++ b/test/mixin_declaration_test.dart
@@ -9,7 +9,7 @@ void main() {
         {
           'kind': 'mixin',
           'name': 'Moo',
-          'on': ['X', 'Y']
+          'on': ['X', 'Y'],
         },
       );
     });
@@ -22,7 +22,7 @@ void main() {
         {
           'kind': 'mixin',
           'name': 'Moo',
-          'implements': ['Sound']
+          'implements': ['Sound'],
         },
       );
     });


### PR DESCRIPTION
A lot of features have been added to the dart language since the previous used version (analyzer 5.4.0). `records`, `patterns`, `class-modifiers` are some to name a few.

This PR upgrades the `analyzer` version so that these features can be supported.

---

_I also ran `dart fix --apply` because my IDE was complaining a lot :)_